### PR TITLE
Add Redis list operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/mitchs-dev/library-go
 
-go 1.22.1
+go 1.23.0
+
 toolchain go1.23.7
 
 require (
 	github.com/dgraph-io/badger v1.6.2
 	github.com/go-redis/redis v6.15.9+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/json-iterator/go v1.1.12
 	github.com/mitchs-dev/build-struct v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/redisTools/redisTools.go
+++ b/redisTools/redisTools.go
@@ -108,7 +108,6 @@ func (r *RedisClient) Set(key string, value string, expirationInHours int) error
 
 // Set a value in Redis with a time.Duration instead of int
 func (r *RedisClient) SetT(key string, value string, expiration time.Duration) error {
-
 	return r.client.Set(key, value, expiration).Err()
 }
 
@@ -184,6 +183,47 @@ func (r *RedisClient) Exists(key string) (bool, error) {
 		return false, err
 	}
 	return exists == 1, nil
+}
+
+// LPush pushes a value to the left of a list returning an err if it fails
+func (r *RedisClient) LPush(key string, value string) error {
+	response := r.client.LPush(key, value)
+	if response.Err() != nil {
+		return response.Err()
+	}
+	return nil
+}
+
+// RPop pops a value from the right of a list returning the value and an err if it fails
+func (r *RedisClient) RPop(key string) (string, error) {
+	response := r.client.RPop(key)
+	if response.Err() != nil {
+		return "", response.Err()
+	}
+	return response.Val(), nil
+}
+
+// BRPop pops a value from the right of a list blocking for a specified duration
+//
+// Note: This will only return the very rightmost value in the list, not all values
+func (r *RedisClient) BRPop(key string, timeout time.Duration) (string, error) {
+	response := r.client.BRPop(timeout, key)
+	if response.Err() != nil {
+		return "", response.Err()
+	}
+	if len(response.Val()) < 2 {
+		return "", errors.New("no value returned from BRPop")
+	}
+	return response.Val()[1], nil
+}
+
+// LLen returns the length of a list
+func (r *RedisClient) LLen(key string) (int64, error) {
+	response := r.client.LLen(key)
+	if response.Err() != nil {
+		return 0, response.Err()
+	}
+	return response.Val(), nil
 }
 
 // For backwards compatibility, these functions create a temporary client

--- a/redisTools/redisTools.go
+++ b/redisTools/redisTools.go
@@ -212,7 +212,7 @@ func (r *RedisClient) BRPop(key string, timeout time.Duration) (string, error) {
 		return "", response.Err()
 	}
 	if len(response.Val()) < 2 {
-		return "", errors.New("no value returned from BRPop")
+		return "", errors.New("BRPop response must include both the key and the value, but the response was shorter than expected")
 	}
 	return response.Val()[1], nil
 }


### PR DESCRIPTION
This pull request introduces updates to dependencies, enhancements to the Redis client utility, and minor code cleanups. The most notable changes include upgrading the Go version, adding new Redis list operations, and introducing a new dependency for UUID generation.

### Dependency Updates:
* Updated the Go version in `go.mod` from `1.22.1` to `1.23.0` and specified the toolchain as `go1.23.7`.
* Added `github.com/google/uuid v1.6.0` as a new dependency in `go.mod`.

### Redis Client Enhancements:
* Added new methods to `RedisClient` in `redisTools/redisTools.go` for list operations:
  - [`LPush`](diffhunk://#diff-0dd25c069279aa586f970b2967df945fed78b4a25acadf4de4571bfc4a6e5717R188-R228): Pushes a value to the left of a list.
  - [`RPop`](diffhunk://#diff-0dd25c069279aa586f970b2967df945fed78b4a25acadf4de4571bfc4a6e5717R188-R228): Pops a value from the right of a list.
  - [`BRPop`](diffhunk://#diff-0dd25c069279aa586f970b2967df945fed78b4a25acadf4de4571bfc4a6e5717R188-R228): Pops a value from the right of a list with blocking support.
  - [`LLen`](diffhunk://#diff-0dd25c069279aa586f970b2967df945fed78b4a25acadf4de4571bfc4a6e5717R188-R228): Returns the length of a list.

### Important

These do **not** have encrypt variants. This was done as, for my use case, performance > security for what I am using these for. Encrypted variants can be added if needed.