### PR TITLE
Add DisloConfig support to RedisConfigEncryption 

### DIFF
--- a/redisTools/redisTools.go
+++ b/redisTools/redisTools.go
@@ -21,7 +21,8 @@ type RedisConfiguration struct {
 }
 
 type RedisConfigEncryption struct {
-	Key []byte
+	Key         []byte
+	DisloConfig *encryption.DisloConfig
 }
 
 type RedisConfigHost struct {
@@ -38,6 +39,15 @@ type RedisClient struct {
 
 // NewRedisClient returns a new Redis client
 func NewRedisClient(config RedisConfiguration) *RedisClient {
+
+	// Initialize dislo, if needed
+	if config.Encryption.DisloConfig != nil {
+		// The encryption package requires an array for the Dislo Config
+		disloConfigMap := make([]*encryption.DisloConfig, 1)
+		disloConfigMap[0] = config.Encryption.DisloConfig
+		encryption.InitializeDisloLock(disloConfigMap)
+	}
+
 	return &RedisClient{
 		client: redis.NewClient(RedisOptions(config)),
 		config: config,


### PR DESCRIPTION
This pull request introduces support for initializing Dislo encryption configuration in the `redisTools` package. The changes ensure that the `RedisClient` can handle encryption-related configurations more flexibly by leveraging the Dislo encryption framework.

Enhancements to encryption configuration:

* [`redisTools/redisTools.go`](diffhunk://#diff-0dd25c069279aa586f970b2967df945fed78b4a25acadf4de4571bfc4a6e5717R25): Added a `DisloConfig` field to the `RedisConfigEncryption` struct to support Dislo encryption configuration.
* [`redisTools/redisTools.go`](diffhunk://#diff-0dd25c069279aa586f970b2967df945fed78b4a25acadf4de4571bfc4a6e5717R42-R50): Updated the `NewRedisClient` function to initialize Dislo encryption if the `DisloConfig` field is provided. This includes creating an array for the Dislo configuration and calling `encryption.InitializeDisloLock`.