### PR TITLE
Enhance Dislo lock initialization to merge existing mutex maps and log warnings for duplicates

### DIFF
--- a/encryption/encryption.go
+++ b/encryption/encryption.go
@@ -143,7 +143,20 @@ func InitializeDisloLock(disloConfigMap []*DisloConfig) {
 		log.Debugf("encryption: Dislo lock initialized for ID: %s", disloConfig.DisloLockID)
 	}
 
-	localDisloMutexMap = initDisloMutexMap
+	if localDisloMutexMap == nil {
+		localDisloMutexMap = initDisloMutexMap
+	} else {
+		// Merge the new Dislo mutex map with the existing one
+		for key, value := range initDisloMutexMap {
+			_, ok := localDisloMutexMap[key]
+			if !ok {
+				localDisloMutexMap[key] = value
+			} else {
+				log.Warnf("encryption: Dislo lock for key %s already exists, skipping initialization", key)
+			}
+		}
+	}
+
 	log.Debugf("encryption: Dislo locks initialized with %d keys", len(localDisloMutexMap))
 }
 


### PR DESCRIPTION
This pull request updates the `InitializeDisloLock` function in `encryption/encryption.go` to handle merging of Dislo mutex maps more robustly. The most significant change ensures that new Dislo mutex entries are added without overwriting existing ones, while logging warnings for duplicate keys.

Enhancements to Dislo mutex map initialization:

* [`encryption/encryption.go`](diffhunk://#diff-2a88fd8ed7caebe049ef314c3d7fefcc6237332180e7a2e63df92191a925908bR146-R159): Updated the `InitializeDisloLock` function to check if `localDisloMutexMap` is nil before initialization. If it is not nil, the new `initDisloMutexMap` is merged with the existing `localDisloMutexMap`. Duplicate keys are skipped, and a warning is logged for each duplicate.